### PR TITLE
Allow 'Workload' and/or 'Environment' fields to be empty

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -35,7 +35,7 @@
 
           <div class="col">
             <label for="instance" class="form-label">Instance</label>
-            <input class="form-control" type="number" id="instance" value.bind="instance" />
+            <input class="form-control" type="number" id="instance" value.bind="instance" min="0" />
           </div>
 
         </div>

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -8,13 +8,13 @@ export interface IFeedback {
 
 export function formatResourceName(selectedResource: IResource, workload: string, environment: string, region: string, instance: number, feedback: IFeedback) {
 
-  let pattern = selectedResource.pattern ?? '{resource}-{workload}-{environment}-{region}';
+  let pattern = selectedResource.pattern ?? '{resource}-{workload}-{environment}-{region}-{instance}';
 
-  if (instance > 0) {
-    pattern += selectedResource.instanceSuffix ?? '-{instance}';
-  }
+  const instanceString = instance > 0 ? String(instance).padStart(3, '0') : '';
 
-  const name = pattern.formatUnicorn({ resource: selectedResource.abbrev, workload: workload, environment: environment, region: region, instance: String(instance).padStart(3, '0') });
+  const name = pattern.formatUnicorn({ resource: selectedResource.abbrev, workload: workload, environment: environment, region: region, instance: instanceString })
+    .replace(/\-+/g, '-') // Remove double dashes (from an empty field)
+    .replace(/\-+$/, ''); // Remove trailing dash(es)
 
   if (name.length > selectedResource?.maxLength) {
     feedback.validationFeedback = `Length exceeds maximum ${selectedResource.maxLength} characters`;

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -377,8 +377,7 @@ export const resources :
       {
         abbrev: 'st',
         name: 'Storage account',
-        pattern: '{resource}{workload}{environment}{region}',
-        instanceSuffix: '{instance}',
+        pattern: '{resource}{workload}{environment}{region}{instance}',
         minLength: 3,
         maxLength: 24,
         regex: /^[a-z0-9]+$/,

--- a/src/resourcetype-list.ts
+++ b/src/resourcetype-list.ts
@@ -5,7 +5,6 @@ export interface IResource {
   abbrev: string;
   name: string;
   pattern?: string;
-  instanceSuffix?: string;
   minLength?: number;
   maxLength?: number;
   regex?: RegExp;

--- a/test/unit/formatting/formatResourceName.spec.ts
+++ b/test/unit/formatting/formatResourceName.spec.ts
@@ -1,0 +1,55 @@
+import { resources } from '../../../src/resources';
+import { formatResourceName } from "formatting";
+import { MockFeedback } from './MockFeedback';
+
+describe('formatting', () => {
+
+  describe('formatResourceName', () => {
+    let feedback: MockFeedback;
+
+    beforeEach( () => {
+      feedback = new MockFeedback();
+    });
+
+    describe('empty fields', () => {
+      const resource = resources.find(f => f.category == 'General').assets.find(a => a.abbrev === 'apim');
+
+      it('empty environment', () => {
+        const result = formatResourceName(
+          resource,
+          'workload',
+          '',
+          'australiasoutheast',
+          1,
+          feedback);
+    
+          expect(result).toMatchInlineSnapshot(`"apim-workload-australiasoutheast-001"`);
+      });
+
+      it('empty environment and workload', () => {
+        const result = formatResourceName(
+          resource,
+          '',
+          '',
+          'australiasoutheast',
+          1,
+          feedback);
+    
+          expect(result).toMatchInlineSnapshot(`"apim-australiasoutheast-001"`);
+      });
+
+      it('zero instance', () => {
+        const result = formatResourceName(
+          resource,
+          'workload',
+          'prod',
+          'australiasoutheast',
+          0,
+          feedback);
+    
+          expect(result).toMatchInlineSnapshot(`"apim-workload-prod-australiasoutheast"`);
+      })
+
+    });
+  });
+});

--- a/test/unit/formatting/storage.spec.ts
+++ b/test/unit/formatting/storage.spec.ts
@@ -1,0 +1,43 @@
+import { resources } from '../../../src/resources';
+import { formatResourceName } from "formatting";
+import { MockFeedback } from './MockFeedback';
+
+describe('formatting', () => {
+
+  describe('storage', () => {
+    let feedback: MockFeedback;
+
+    beforeEach( () => {
+      feedback = new MockFeedback();
+    });
+
+    describe('st', () => {
+      const resource = resources.find(f => f.category == 'Storage').assets.find(a => a.abbrev === 'st');
+
+      it('valid', () => {
+        const result = formatResourceName(
+          resource,
+          'workload',
+          'prod',
+          'eastus',
+          1,
+          feedback);
+    
+          expect(result).toMatchInlineSnapshot(`"stworkloadprodeastus001"`);
+      });
+
+      it('invalid', () => {
+        formatResourceName(
+          resource,
+          'workloadthatmakesnametoolong',
+          'prod',
+          'eastus',
+          1,
+          feedback);
+    
+          expect(feedback.resourceNameValid).toBe(false);
+      });
+    });
+
+  });
+})


### PR DESCRIPTION
- Simplify how we manage the formatting pattern
- Add tests for storage account
- Stop instance from going negative

Resolves #83